### PR TITLE
Compatibility with pool-request 15 in websockets. There is secure connection flag in RequestHttpPart now.

### DIFF
--- a/src/Network/WebSockets/Snap.hs
+++ b/src/Network/WebSockets/Snap.hs
@@ -37,4 +37,5 @@ fromSnapRequest :: Snap.Request -> WS.RequestHttpPart
 fromSnapRequest rq = WS.RequestHttpPart
     { WS.requestHttpPath    = Snap.rqURI rq
     , WS.requestHttpHeaders = Headers.toList (Snap.rqHeaders rq)
+    , WS.requestHttpSecure = Snap.rqIsSecure rq
     }


### PR DESCRIPTION
[link](https://github.com/jaspervdj/websockets/pull/15)
