### PR TITLE
Refer to (MonadSnap m) instead of Snap

### DIFF
--- a/src/Network/WebSockets/Snap.hs
+++ b/src/Network/WebSockets/Snap.hs
@@ -13,16 +13,16 @@ import qualified Snap.Types.Headers as Headers
 -- continues processing the 'WS.WebSockets' action. The action to be executed
 -- takes the 'WS.Request' as a parameter, because snap has already read this
 -- from the socket.
-runWebSocketsSnap :: WS.Protocol p
+runWebSocketsSnap :: (Snap.MonadSnap m, WS.Protocol p)
                   => (WS.Request -> WS.WebSockets p ())
-                  -> Snap.Snap ()
+                  -> m ()
 runWebSocketsSnap = runWebSocketsSnapWith WS.defaultWebSocketsOptions
 
 -- | Variant of 'runWebSocketsSnap' which allows custom options
-runWebSocketsSnapWith :: WS.Protocol p
+runWebSocketsSnapWith :: (Snap.MonadSnap m, WS.Protocol p)
                       => WS.WebSocketsOptions
                       -> (WS.Request -> WS.WebSockets p ())
-                      -> Snap.Snap ()
+                      -> m ()
 runWebSocketsSnapWith options ws = do
     rq <- Snap.getRequest
     Snap.escapeHttp $ \tickle writeEnd ->

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -1,5 +1,5 @@
 Name:          websockets-snap
-Version:       0.7.0.0
+Version:       0.7.0.1
 Synopsis:      Snap integration for the websockets library
 Description:   Snap integration for the websockets library
 License:       BSD3


### PR DESCRIPTION
Using MonadSnap m makes it easier to call websockets wrapper from snaplet handlers since snaplets live in their own monads
