### PR TITLE
io-streams

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/snap"]
+	path = deps/snap
+	url = http://github.com/snapframework/snap

--- a/example/console.html
+++ b/example/console.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>WebSockets Console</title>
+        <link rel="stylesheet" type="text/css" href="style.css" />
+        <script type="text/javascript"
+            src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+        <script type="text/javascript" src="console.js"></script>
+    </head>
+    <body>
+        <div>
+            <form id="login">
+                <code>URI: </code><input type="text" size="64" id="uri"
+                        value="ws://localhost:8000/console/bash" />
+                <input type="submit" style="display: none" />
+            </form>
+            <div id="console" style="display: none">
+                <div id="console-output"></div>
+                <form id="console-input">
+                    <code>$ </code><input type="text" size="64" id="line" />
+                    <input type="submit" style="display: none" />
+                </form>
+            </div>
+        </div>
+    </body>
+</html>

--- a/example/console.js
+++ b/example/console.js
@@ -1,0 +1,45 @@
+function appendOutput(cls, text) {
+    $('#console-output').append('<pre class="' + cls + '">' + text + '</pre>');
+    $('#line').focus();
+}
+
+$(document).ready(function () {
+    var ws;
+
+    $('#uri').focus();
+
+    $('#login').submit(function () {
+        var uri = $('#uri').val();
+        $('#login').css('display', 'none');
+        $('#console').css('display', 'block');
+
+        ws = new WebSocket(uri);
+        appendOutput('stderr', 'Opening WebSockets connection...\n');
+
+        ws.onerror = function(event) {
+            appendOutput('stderr', 'WebSockets error: ' + event.data + '\n');
+        };
+
+        ws.onopen = function() {
+            appendOutput('stderr', 'WebSockets connection successful!\n');
+        };
+
+        ws.onclose = function() {
+            appendOutput('stderr', 'WebSockets connection closed.\n');
+        };
+
+        ws.onmessage = function(event) {
+            appendOutput('stdout', event.data);
+        };
+
+        return false;
+    });
+
+    $('#console-input').submit(function () {
+        var line = $('#line').val();
+        ws.send(line + '\n');
+        appendOutput('stdin', line + '\n');
+        $('#line').val('');
+        return false;
+    });
+});

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -1,0 +1,49 @@
+Name:          example
+Version:       1.0.0.0
+Synopsis:      Snap integration for the websockets library
+Description:   Snap integration for the websockets library
+License:       BSD3
+License-file:  LICENSE
+Author:        Jasper Van der Jeugt <m@jaspervdj.be>
+Maintainer:    Jasper Van der Jeugt <m@jaspervdj.be>
+Category:      Network
+Build-type:    Simple
+Cabal-version: >= 1.6
+
+Executable example
+  Main-is: server.hs
+ 
+ Build-depends:
+    base        >= 4   && < 5,
+    blaze-builder,
+    bytestring,
+    io-streams,
+    mtl,
+    process,
+    snap-core       >= 1.0 && < 1.1,
+    snap-server     >= 1.0 && < 1.1,
+    text,
+    transformers,
+    websockets      >= 0.9.5 && < 0.10,
+    websockets-snap >= 1.0.0.0 && < 1.1
+
+Executable meow
+  Main-is: meow.hs
+
+  Build-depends:
+    base        >= 4   && < 5,
+    blaze-builder,
+    bytestring,
+    io-streams,
+    mtl,
+    process,
+    snap-core       >= 1.0 && < 1.1,
+    snap-server     >= 1.0 && < 1.1,
+    text,
+    transformers,
+    websockets      >= 0.9.5 && < 0.10,
+    websockets-snap >= 1.0.0.0 && < 1.1
+
+Source-repository head
+  Type:     git
+  Location: https://github.com/jaspervdj/websockets-snap

--- a/example/meow.hs
+++ b/example/meow.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import           Control.Monad      (forever)
+import qualified Data.Text          as T
+import qualified Network.WebSockets as WS
+
+main :: IO ()
+main = WS.runServer "127.0.0.1" 8000 $ \p -> do
+  conn <- WS.acceptRequest p
+  meow conn
+
+meow :: WS.Connection -> IO ()
+meow conn = forever $ do
+    msg <- WS.receiveData conn
+    WS.sendTextData conn $ msg `T.append` ", meow"

--- a/example/server.hs
+++ b/example/server.hs
@@ -1,0 +1,109 @@
+--------------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+
+--------------------------------------------------------------------------------
+import           Control.Concurrent      (forkIO, threadDelay)
+import           Control.Exception       (finally)
+import           Control.Monad           (forever, unless)
+import           Control.Monad.IO.Class  (liftIO)
+import qualified Data.ByteString         as B
+import qualified Data.ByteString.Char8   as BC
+import qualified Data.Text               as T
+import qualified Network.WebSockets      as WS
+import qualified Network.WebSockets.Snap as WS
+import           Snap.Core               (Snap)
+import qualified Snap.Core               as Snap
+import qualified Snap.Http.Server.Config as Snap
+import qualified Snap.Http.Server        as Snap
+import qualified Snap.Util.FileServe     as Snap
+import qualified System.IO               as IO
+import qualified System.Process          as Process
+
+
+--------------------------------------------------------------------------------
+app :: Snap ()
+app = Snap.route
+    [ ("",               Snap.ifTop $ Snap.serveFile "console.html")
+    , ("console.js",     Snap.serveFile "console.js")
+    , ("console/:shell", console)
+    , ("style.css",      Snap.serveFile "style.css")
+    , ("text",           WS.runWebSocketsSnap consoleApp2)
+    , ("meow",           WS.runWebSocketsSnap meow)
+    ]
+
+
+--------------------------------------------------------------------------------
+console :: Snap ()
+console = do
+    Just shell <- Snap.getParam "shell"
+    WS.runWebSocketsSnap $ consoleApp $ BC.unpack shell
+
+
+meow :: WS.PendingConnection -> IO ()
+meow p = do
+  conn <- WS.acceptRequest p
+  forever $ do
+    msg <- WS.receiveData conn
+    WS.sendTextData conn $ msg `T.append` ", meow"
+
+
+--------------------------------------------------------------------------------
+consoleApp :: String -> WS.ServerApp
+consoleApp shell pending = do
+    liftIO $ putStrLn "STARTING CONSOLE APP"
+    (stdin, stdout, stderr, phandle) <- Process.runInteractiveCommand shell
+    liftIO $ putStrLn "ACCEPTREQUEST waiting"
+    conn                             <- WS.acceptRequest pending
+    liftIO $ putStrLn "ACCEPTREQUEST returned"
+
+    liftIO $ putStrLn "FORKING copyHandle etc"
+    _ <- forkIO $ copyHandleToConn stdout conn
+    _ <- forkIO $ copyHandleToConn stderr conn
+    _ <- forkIO $ copyConnToHandle conn stdin
+    liftIO $ putStrLn "DONE FORKING copyHandle etc"
+
+    liftIO $ putStrLn "WAITING for processes to finish"
+    exitCode <- Process.waitForProcess phandle
+    liftIO $ putStrLn "PROCESS FINISHED"
+    putStrLn $ "consoleApp ended: " ++ show exitCode
+
+
+consoleApp2 :: WS.ServerApp
+consoleApp2 pending = do
+  conn <- WS.acceptRequest pending
+  putStrLn "console2"
+  forever $ do
+    WS.sendTextData conn ("HELLO!" :: T.Text)
+    putStrLn "Sent data"
+    threadDelay 500000
+
+--------------------------------------------------------------------------------
+copyHandleToConn :: IO.Handle -> WS.Connection -> IO ()
+copyHandleToConn h c = do
+    bs <- B.hGetSome h 1024
+    unless (B.null bs) $ do
+        putStrLn $ "> " ++ show bs
+        WS.sendTextData c bs
+        copyHandleToConn h c
+
+
+--------------------------------------------------------------------------------
+copyConnToHandle :: WS.Connection -> IO.Handle -> IO ()
+copyConnToHandle c h = flip finally (IO.hClose h) $ forever $ do
+    bs <- WS.receiveData c
+    putStrLn $ "< " ++ show bs
+    B.hPutStr h bs
+    IO.hFlush h
+
+
+--------------------------------------------------------------------------------
+main :: IO ()
+main = Snap.httpServe config app
+  where
+    config =
+        --Snap.setErrorLog  Snap.ConfigNoLog $
+        --Snap.setAccessLog Snap.ConfigNoLog $
+        -- Snap.defaultConfig
+        (Snap.setPort 8000 mempty)

--- a/example/style.css
+++ b/example/style.css
@@ -1,0 +1,41 @@
+body {
+    margin: 18px;
+    font-family: 'Inconsolata', monospace;
+    font-size: 16px;
+    background-color: #444;
+}
+
+form {
+    color: #cfc;
+    font-family: 'Inconsolata', monospace;
+    font-size: 16px;
+    margin-top: 6px;
+}
+
+form input {
+    background-color: #444;
+    border: 1px solid #777;
+    color: #cfc;
+    font-family: 'Inconsolata', monospace;
+    font-size: 16px;
+    margin: 0px;
+    padding: 0px;
+}
+
+pre {
+    margin: 0px;
+    padding: 0px;
+    display: inline;
+}
+
+pre.stderr {
+    color: #fcc;
+}
+
+pre.stdout {
+    color: #ccc;
+}
+
+pre.stdin {
+    color: #cfc;
+}

--- a/src/Network/WebSockets/Snap.hs
+++ b/src/Network/WebSockets/Snap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-} -- TODO for testing
 {-# LANGUAGE FlexibleContexts #-}  -- TODO for testing
 
 --------------------------------------------------------------------------------
@@ -12,18 +13,21 @@ module Network.WebSockets.Snap
 --------------------------------------------------------------------------------
 import           Blaze.ByteString.Builder      (Builder)
 import qualified Blaze.ByteString.Builder      as Builder
-import           Control.Concurrent            (forkIO, myThreadId)
+import           Control.Concurrent            (forkIO, myThreadId, threadDelay)
 import           Control.Concurrent.MVar       (MVar, newEmptyMVar, putMVar,
                                                 takeMVar)
 import           Control.Exception             (Exception (..),
-                                                SomeException (..), throw,
-                                                throwTo)
+                                                SomeException (..), handle,
+                                                throw, throwTo)
+import           Control.Monad                 (forever)
+import           Control.Monad.IO.Class        (liftIO)
 import           Control.Monad.Trans           (lift)
+import           Data.Bool                     (bool)
 import           Data.ByteString               (ByteString)
+import qualified Data.ByteString.Char8         as BC
 import qualified Data.ByteString.Builder       as BSBuilder
 import qualified Data.ByteString.Builder.Extra as BSBuilder
 import qualified Data.ByteString.Lazy          as BL
---import qualified Data.Enumerator               as E
 import           Data.IORef                    (newIORef, readIORef, writeIORef)
 import           Data.Monoid                   ((<>))
 import           Data.Typeable                 (Typeable, cast)
@@ -33,9 +37,13 @@ import qualified Network.WebSockets.Stream     as WS
 import qualified Snap.Core                     as Snap
 import qualified Snap.Internal.Http.Types      as Snap
 import qualified Snap.Types.Headers            as Headers
+import           System.IO                     (hFlush, stdout)
 import           System.IO.Streams             (InputStream, OutputStream)
 import qualified System.IO.Streams             as Streams
+import Data.ByteString.Builder.Extra           (flush)
 import qualified System.IO.Streams.Combinators as Streams
+import qualified System.IO.Streams.Handle      as Streams
+import qualified System.IO.Streams.Debug       as Streams
 
 
 --------------------------------------------------------------------------------
@@ -67,6 +75,9 @@ runWebSocketsSnap :: WS.ServerApp
 runWebSocketsSnap = runWebSocketsSnapWith WS.defaultConnectionOptions
 
 
+dropEmpty :: String -> Maybe String
+dropEmpty s = bool (Just s) Nothing (null s)
+
 --------------------------------------------------------------------------------
 -- | Variant of 'runWebSocketsSnap' which allows custom options
 runWebSocketsSnapWith :: WS.ConnectionOptions
@@ -75,38 +86,51 @@ runWebSocketsSnapWith :: WS.ConnectionOptions
 runWebSocketsSnapWith options app = do
   rq <- Snap.getRequest
   Snap.escapeHttp $ \tickle readEnd writeEnd -> do
+    let tickle' f = print "(calling Tickle)" >> tickle f
+    readEnd'  <- Streams.lockingInputStream  readEnd
+    writeEnd' <- Streams.lockingOutputStream writeEnd
 
-    let debugRead s = do
-          putStrLn "About to read"
-          r <- Streams.read s
-          putStrLn $ "Read " ++ show r
-          return r
-
-    let debugWrite v s = do
-          putStrLn $ "About to write " ++ show (BSBuilder.toLazyByteString <$> v)
-          r <- Streams.write v s
-          putStrLn $ "Wrote"
+    readEnd'' <- Streams.debugInput id "InputStream: " Streams.stdout readEnd'
+    writeEnd'' <- Streams.debugOutput (BL.toStrict . BSBuilder.toLazyByteString) "OutputStream: " Streams.stdout writeEnd'
 
     thisThread <- myThreadId
-    stream <- WS.makeStream
-              (Streams.read readEnd)
-              (\v ->
-                 Streams.write (((<> BSBuilder.flush) . BSBuilder.lazyByteString) <$> v) writeEnd
-              )
+    stream <- WS.makeStream (Streams.read readEnd'')
+              (\v -> Streams.write (fmap BSBuilder.lazyByteString v) writeEnd'' >>
+                     Streams.write (Just flush) writeEnd'')
+    liftIO $ print "Done making stream"
 
     let options' = options
                    { WS.connectionOnPong = do
-                        tickle (max 30)
+                        print "GOT A PONG"
+                        hFlush stdout
+                        tickle' (max 30)
                         WS.connectionOnPong options
                    }
 
         pc = WS.PendingConnection
-               { WS.pendingOptions = options'
-               , WS.pendingRequest = fromSnapRequest rq
-               , WS.pendingOnAccept = \_ -> return ()
+               { WS.pendingOptions  = options'
+               , WS.pendingRequest  = fromSnapRequest rq
+               , WS.pendingOnAccept = forkPingThread tickle'
                , WS.pendingStream   = stream
                }
-    app pc >> throwTo thisThread ServerAppDone
+    app pc >> print "app exited" >> throwTo thisThread ServerAppDone
+
+
+--------------------------------------------------------------------------------
+-- | Start a ping thread in the background
+forkPingThread :: ((Int -> Int) -> IO ()) -> WS.Connection -> IO ()
+forkPingThread tickle conn = do
+    _ <- forkIO pingThread
+    return ()
+  where
+    pingThread = handle ignore $ forever $ do
+        WS.sendPing conn (BC.pack "ping")
+        print "TICKLING"
+        tickle (min 30)
+        threadDelay $ 5 * 1000 * 1000
+
+    ignore :: SomeException -> IO ()
+    ignore _   = return ()
 
 
 --------------------------------------------------------------------------------
@@ -117,5 +141,3 @@ fromSnapRequest rq = WS.RequestHead
     , WS.requestHeaders = Headers.toList (Snap.rqHeaders rq)
     , WS.requestSecure  = Snap.rqIsSecure rq
     }
-
-    

--- a/src/Network/WebSockets/Snap.hs
+++ b/src/Network/WebSockets/Snap.hs
@@ -94,7 +94,7 @@ runWebSocketsSnapWith options app = do
     writeEnd'' <- Streams.debugOutput (BL.toStrict . BSBuilder.toLazyByteString) "OutputStream: " Streams.stdout writeEnd'
 
     thisThread <- myThreadId
-    stream <- WS.makeStream (Streams.read readEnd'')
+    stream <- WS.makeStream (tickle (max 20) >> Streams.read readEnd'')
               (\v -> Streams.write (fmap BSBuilder.lazyByteString v) writeEnd'' >>
                      Streams.write (Just flush) writeEnd'')
     liftIO $ print "Done making stream"

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -19,7 +19,7 @@ Library
   Build-depends:
     base        >= 4   && < 5,
     snap-core   >= 1.0 && < 1.1,
-    snap-server >= 1.0 && < 0.1,
+    snap-server >= 1.0 && < 1.1,
     websockets  >= 0.7 && < 0.8
 
 Source-repository head

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -24,6 +24,7 @@ Library
     mtl,
     snap-core   >= 1.0 && < 1.1,
     snap-server >= 1.0 && < 1.1,
+    transformers,
     websockets  >= 0.9.5 && < 0.10
 
 Source-repository head

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -20,7 +20,7 @@ Library
     base        >= 4   && < 5,
     snap-core   >= 1.0 && < 1.1,
     snap-server >= 1.0 && < 1.1,
-    websockets  >= 0.7 && < 0.8
+    websockets  >= 0.9.5 && < 0.10
 
 Source-repository head
   Type:     git

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -1,5 +1,5 @@
 Name:          websockets-snap
-Version:       0.7.0.0
+Version:       1.0.0.0
 Synopsis:      Snap integration for the websockets library
 Description:   Snap integration for the websockets library
 License:       BSD3
@@ -18,8 +18,8 @@ Library
 
   Build-depends:
     base        >= 4   && < 5,
-    snap-core   >= 0.8 && < 0.10,
-    snap-server >= 0.8 && < 0.10,
+    snap-core   >= 1.0 && < 1.1,
+    snap-server >= 1.0 && < 0.1,
     websockets  >= 0.7 && < 0.8
 
 Source-repository head

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -18,6 +18,10 @@ Library
 
   Build-depends:
     base        >= 4   && < 5,
+    blaze-builder,
+    bytestring,
+    io-streams,
+    mtl,
     snap-core   >= 1.0 && < 1.1,
     snap-server >= 1.0 && < 1.1,
     websockets  >= 0.9.5 && < 0.10


### PR DESCRIPTION
Hi. Please don't merge yet.

Would you mind taking a look at this (especially the changes to `Network.WebSockets.Snap`)?

Where this is right now: the `meow` route works, insofar as I can reach `ws://localhost:8000/meow` from a new websocket object created from the browser's javascript console, set its `.onmessage` callback to print, call `.send('message')`, and get back 'message, meow' in console.log.

That's promising, but I worry because your bash caller example isn't working. The websocket reports that it has connected, but no data comes back in response to bash commands.

Note about snap 1.0: I've included it as a git submodule, to make this a bit easier to test. Thanks!