### PR TITLE
Bump io-streams upper bound to 1.6

### DIFF
--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -25,7 +25,7 @@ Library
     base               >= 4     && < 5,
     bytestring         >= 0.9   && < 0.11,
     bytestring-builder >= 0.10  && < 0.11,
-    io-streams         >= 1.3   && < 1.5,
+    io-streams         >= 1.3   && < 1.6,
     mtl                >= 2.1   && < 2.3,
     snap-core          >= 1.0   && < 1.1,
     snap-server        >= 1.0   && < 1.1,

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -1,5 +1,5 @@
 Name:          websockets-snap
-Version:       0.10.2.3
+Version:       0.10.2.4
 Synopsis:      Snap integration for the websockets library
 Description:   Snap integration for the websockets library
 License:       BSD3


### PR DESCRIPTION
Hi, hopefully this is ok (two changes, the upper bound to 1.6 and version number 0.10.2.4). Did test this by having lower bound 1.5 and the example program worked, no other tests done.