### PR TITLE
Bump snap-server to 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 0.10.2.5
+    * Bump snap-server to 1.1
+
 - 0.10.2.4 (2017-11-26)
     * Bump io-streams to 1.5
 

--- a/example/websockets-snap-example.cabal
+++ b/example/websockets-snap-example.cabal
@@ -18,6 +18,6 @@ executable websockets-snap-example
     bytestring       >= 0.10     && < 0.11,
     process          >= 1.2      && < 1.7,
     snap-core        >= 1.0      && < 1.1,
-    snap-server      >= 1.0      && < 1.1,
+    snap-server      >= 1.0      && < 1.2,
     websockets       >= 0.9.5    && < 0.13,
     websockets-snap  >= 0.10.0.0 && < 0.11

--- a/websockets-snap.cabal
+++ b/websockets-snap.cabal
@@ -1,5 +1,5 @@
 Name:          websockets-snap
-Version:       0.10.2.4
+Version:       0.10.2.5
 Synopsis:      Snap integration for the websockets library
 Description:   Snap integration for the websockets library
 License:       BSD3
@@ -28,7 +28,7 @@ Library
     io-streams         >= 1.3   && < 1.6,
     mtl                >= 2.1   && < 2.3,
     snap-core          >= 1.0   && < 1.1,
-    snap-server        >= 1.0   && < 1.1,
+    snap-server        >= 1.0   && < 1.2,
     websockets         >= 0.9.5 && < 0.13
 
 Source-repository head


### PR DESCRIPTION
This version is compatible with GHC-8.4.1.