### PR TITLE
Increase ping thread frequency, extend Snap timeout by at least 60s

### DIFF
--- a/src/Network/WebSockets/Snap.hs
+++ b/src/Network/WebSockets/Snap.hs
@@ -100,8 +100,8 @@ forkPingThread tickle conn = do
   where
     pingThread = handle ignore $ forever $ do
         WS.sendPing conn (BC.pack "ping")
-        tickle (max 15)
-        threadDelay $ 30 * 1000 * 1000
+        tickle (max 60)
+        threadDelay $ 10 * 1000 * 1000
 
     ignore :: SomeException -> IO ()
     ignore _   = return ()


### PR DESCRIPTION
This is a workaround for WebSockets closing prematurely, seems to fix a
regression between 0.9.2.0 -> 0.10.2.4

As discussed in https://github.com/jaspervdj/websockets/issues/127, this is my quick fix for an issue that *seems* to exist in 0.10.2.4.